### PR TITLE
fix: Use asyncio sleep in async contexts

### DIFF
--- a/bugbounty_gpt/handlers/bugcrowd_api.py
+++ b/bugbounty_gpt/handlers/bugcrowd_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import httpx
 import logging
@@ -70,7 +71,7 @@ class BugCrowdAPI:
             all_submissions.extend(submissions)
             page_offset += page_limit
 
-            time.sleep(delay)  # Add a delay between API calls
+            await asyncio.sleep(delay)  # Add a delay between API calls
 
         return all_submissions if all_submissions else None
 

--- a/bugbounty_gpt/handlers/bugcrowd_api.py
+++ b/bugbounty_gpt/handlers/bugcrowd_api.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import httpx
 import logging
-import time
 from bugbounty_gpt.env import API_BASE_URL, BUGCROWD_API_KEY
 
 logger = logging.getLogger(__name__)

--- a/bugbounty_gpt/handlers/openai_handler.py
+++ b/bugbounty_gpt/handlers/openai_handler.py
@@ -74,7 +74,8 @@ class OpenAIHandler:
         :return: A tuple containing the judgment category and explanation, or an error response if something goes wrong.
         """
         logger.info("Classifying submission's content.")
-        time.sleep(5)  # Consider replacing with a more robust rate-limiting strategy
+        # TODO: Consider replacing with a more robust rate-limiting strategy
+        await asyncio.sleep(5)
         try:
             request_data = OpenAIHandler._build_request_data(submission_content)
             loop = asyncio.get_running_loop()

--- a/bugbounty_gpt/handlers/openai_handler.py
+++ b/bugbounty_gpt/handlers/openai_handler.py
@@ -1,5 +1,4 @@
 import openai
-import time
 import logging
 import asyncio
 from bugbounty_gpt.env import VALID_CATEGORIES, OPENAI_PROMPT, OPENAI_MODEL, DEFAULT_CATEGORY

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def mock_async_sleep(mocker):
+    return mocker.patch("asyncio.sleep")

--- a/tests/test_bugcrowd_api_client.py
+++ b/tests/test_bugcrowd_api_client.py
@@ -24,13 +24,18 @@ async def test_fetch_page():
         submissions = await BugCrowdAPI._fetch_page(url, params, page_limit, page_offset) # await the async function
         assert submissions == ["submission1", "submission2"]  # No await here
 
+
 @pytest.mark.asyncio
-async def test_fetch_submissions():
+async def test_fetch_submissions(mocker, mock_async_sleep):
     params = {"param": "value"}
-    with patch("bugbounty_gpt.handlers.bugcrowd_api.BugCrowdAPI._fetch_page", new_callable=AsyncMock) as mock_fetch_page:
-        mock_fetch_page.side_effect = [["submission1", "submission2"], []]
-        submissions = await BugCrowdAPI.fetch_submissions(params)
-        assert submissions == ["submission1", "submission2"]
+    mock_fetch_page = mocker.patch(
+        "bugbounty_gpt.handlers.bugcrowd_api.BugCrowdAPI._fetch_page",
+        new_callable=AsyncMock,
+    )
+    mock_fetch_page.side_effect = [["submission1", "submission2"], []]
+    submissions = await BugCrowdAPI.fetch_submissions(params)
+    assert submissions == ["submission1", "submission2"]
+
 
 @pytest.mark.asyncio
 async def test_fetch_submission():


### PR DESCRIPTION
Previously there were calls to `time.sleep` in async functions - as this is a blocking call, it ruins any advantages of using async and halts all operations. Switching to `asyncio.sleep` allows the async executor to redirect to a different process if available

Also, these sleeps weren't being mocked in the unit tests which caused the tests to take an additional ~7 seconds. They now complete in ~25ms